### PR TITLE
Use existing checkout

### DIFF
--- a/shared-mailbox-toolkit-installer.sh
+++ b/shared-mailbox-toolkit-installer.sh
@@ -68,10 +68,13 @@ else
 fi
 
 TMPFOLDER="$(mktemp -d /tmp/shared-mailbox-toolkit-installer.XXXXXXXX)"
-echo "Download Shared Mailbox Toolkit to $TMPFOLDER"
-cd $TMPFOLDER
-git clone --depth=1 git://github.com/Zimbra-Community/shared-mailbox-toolkit
-cd shared-mailbox-toolkit
+
+if ! git remote -v | grep /shared-mailbox-toolkit.git; then
+  echo "Download Shared Mailbox Toolkit to $TMPFOLDER"
+  cd $TMPFOLDER
+  git clone --depth=1 git://github.com/Zimbra-Community/shared-mailbox-toolkit
+  cd shared-mailbox-toolkit
+fi
 
 if [[ $1 == *"Client Zimlet"* ]]
 then

--- a/shared-mailbox-toolkit-installer.sh
+++ b/shared-mailbox-toolkit-installer.sh
@@ -34,7 +34,6 @@ if [ -z "$1"  ]
    echo "Check if yum/apt installed."
    set +e
    YUM_CMD=$(which yum)
-   APT_CMD=$(which apt-get)
    set -e 
    
    if [[ ! -z $YUM_CMD ]]; then
@@ -58,7 +57,6 @@ fi
 echo "Check if git and zip are installed."
 set +e
 YUM_CMD=$(which yum)
-APT_CMD=$(which apt-get)
 set -e 
 
 if [[ ! -z $YUM_CMD ]]; then


### PR DESCRIPTION
This makes it possible to git-checkout a pinned version e.g. with a configuration-management-framework like puppet or salt and install it automagically.
The original would always install master even though it had changed since last testing.