### PR TITLE
Clone shared-mailbox-toolkit project from public url.

### DIFF
--- a/shared-mailbox-toolkit-installer.sh
+++ b/shared-mailbox-toolkit-installer.sh
@@ -70,7 +70,7 @@ TMPFOLDER="$(mktemp -d /tmp/shared-mailbox-toolkit-installer.XXXXXXXX)"
 if ! git remote -v | grep /shared-mailbox-toolkit.git; then
   echo "Download Shared Mailbox Toolkit to $TMPFOLDER"
   cd $TMPFOLDER
-  git clone --depth=1 git://github.com/Zimbra-Community/shared-mailbox-toolkit
+  git clone --depth=1 https://github.com/Zimbra-Community/shared-mailbox-toolkit
   cd shared-mailbox-toolkit
 fi
 


### PR DESCRIPTION
Fix issue #67 by cloning shared-mailbox-toolkit project from public url.